### PR TITLE
Increase timeout in manifests/pycortex.pp

### DIFF
--- a/manifests/pycortex.pp
+++ b/manifests/pycortex.pp
@@ -28,7 +28,7 @@ define neurovault::pycortex (
     creates => $pycortex_path,
     user => $system_user,
     cwd => $pycortex_install_root,
-	timeout => 2000
+	timeout => 10000
   } ->
 
   exec { "build-pycortex":


### PR DESCRIPTION
Increase timeount from 2000 to 10000 to fix timeout error in installation
