### PR TITLE
Using a PostgreSQL hstore extension in the database

### DIFF
--- a/manifests/main.pp
+++ b/manifests/main.pp
@@ -53,6 +53,11 @@ define neurovault::main (
 
   class { 'postgresql::server': }
 
+  # Get hstore contrib
+  class { 'postgresql::server::contrib':
+    package_ensure => 'present',
+  }
+
   $app_path = "$env_path/NeuroVault"
 
   # Add most paths
@@ -262,6 +267,11 @@ define neurovault::main (
   postgresql::server::db { $db_name:
     user => $db_username,
     password => postgresql_password($db_username, $db_userpassword)
+  } ->
+
+  postgresql::server::extension { 'hstore':
+    database => $db_name,
+    ensure => present,
   } ->
 
   neurovault::database { 'setup_db':


### PR DESCRIPTION
This adds a PostgreSQL hstore extension to the NeuroVault's database.

The pull request accompanies https://github.com/NeuroVault/NeuroVault/pull/234.
